### PR TITLE
Enhancement: Add `prerelease` flag based on Tag 

### DIFF
--- a/actions/github/release/create/action.yaml
+++ b/actions/github/release/create/action.yaml
@@ -33,13 +33,15 @@ runs:
             return;
           }
 
+          const isReleaseCanditateTag = process.env.RELEASE_TAG.includes("rc");
+
           try {
             await github.rest.repos.createRelease({
               draft: false,
               generate_release_notes: true,
               name: process.env.RELEASE_TAG,
               owner: context.repo.owner,
-              prerelease: false,
+              prerelease: isReleaseCanditateTag,
               repo: context.repo.repo,
               tag_name: process.env.RELEASE_TAG,
             });


### PR DESCRIPTION
This pull request

- [x] Adds `prerelease` flag when creating a release if the Tag contains `rc` text

