### PR TITLE
Enhancement: Update `actions/github-script` from `v5` to `v6`

### DIFF
--- a/actions/github/release/create/action.yaml
+++ b/actions/github/release/create/action.yaml
@@ -23,7 +23,7 @@ runs:
       shell: "bash"
 
     - name: "Create release"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |


### PR DESCRIPTION
This pull request

- [x] Update `actions/github-script` from `v5` to `v6``

>[!NOTE]
> Fixes the following error:
>The following actions uses node12 which is deprecated and will be forced to run on node16: actions/github-script@v5. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
