### PR TITLE
Feature: Update `github-script` to `v6`

### DIFF
--- a/actions/github/pull-request/add-assignee/action.yaml
+++ b/actions/github/pull-request/add-assignee/action.yaml
@@ -22,7 +22,7 @@ runs:
 
   steps:
     - name: "Determine pull request number"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
@@ -44,7 +44,7 @@ runs:
           core.setFailed(`Unable to determine the pull request number for event "${context.eventName}"`);
 
     - name: "Add assignee to pull request"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       env:
         ASSIGNEE: "${{ inputs.assignee }}"
       with:

--- a/actions/github/pull-request/add-label-based-on-branch-name/action.yaml
+++ b/actions/github/pull-request/add-label-based-on-branch-name/action.yaml
@@ -19,7 +19,7 @@ runs:
 
   steps:
     - name: "Determine pull request number"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
@@ -43,7 +43,7 @@ runs:
           core.setFailed(`Unable to determine the pull request number and branch name for event "${context.eventName}"`);
 
     - name: "Add label to pull request based on branch name"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |

--- a/actions/github/pull-request/approve/action.yaml
+++ b/actions/github/pull-request/approve/action.yaml
@@ -19,7 +19,7 @@ runs:
 
   steps:
     - name: "Determine pull request number"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
@@ -41,7 +41,7 @@ runs:
           core.setFailed(`Unable to determine the pull request number for event "${context.eventName}"`);
 
     - name: "Approve pull request"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |

--- a/actions/github/pull-request/merge/action.yaml
+++ b/actions/github/pull-request/merge/action.yaml
@@ -23,7 +23,7 @@ runs:
 
   steps:
     - name: "Determine pull request number"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
@@ -45,7 +45,7 @@ runs:
           core.setFailed(`Unable to determine the pull request number for event "${context.eventName}"`);
 
     - name: "Merge pull request"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       env:
         MERGE_METHOD: "${{ inputs.merge-method }}"
       with:

--- a/actions/github/pull-request/request-review/action.yaml
+++ b/actions/github/pull-request/request-review/action.yaml
@@ -22,7 +22,7 @@ runs:
 
   steps:
     - name: "Determine pull request number"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
@@ -44,7 +44,7 @@ runs:
           core.setFailed(`Unable to determine the pull request number for event "${context.eventName}"`);
 
     - name: "Request reviewer"
-      uses: "actions/github-script@v5"
+      uses: "actions/github-script@v6"
       env:
         REVIEWER: "${{ inputs.reviewer }}"
       with:


### PR DESCRIPTION
This pull request

- [x] Update `github-script` action from `v5` to `v6`

>[!NOTE]
> Fixes following warning:
>The following actions uses node12 which is deprecated and will be forced to run on node16: actions/github-script@v5. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
